### PR TITLE
Bug fixed, now CalendarEventList will return 404 for not exist calendar

### DIFF
--- a/skdue_calendar/tests/test_views_calendareventlist.py
+++ b/skdue_calendar/tests/test_views_calendareventlist.py
@@ -34,7 +34,7 @@ class CalendarEventListTests(TestCase):
         """Response code is 404 when calendar does not exist"""
         calendar_slug = "not-exist-calendar"
         response = self.client.get(reverse('skdue_calendar:event_list', args=[calendar_slug]))
-        self.assertEqual(json.dumps([]), convert_response(response.content))
+        self.assertEqual(404, response.status_code)
 
     def test_get(self):
         calendar_slug = "calendar"

--- a/skdue_calendar/views.py
+++ b/skdue_calendar/views.py
@@ -47,8 +47,9 @@ class CalendarEventList(APIView):
     """Request for list of events in an calendar or create new events in that calendar."""
     def get_object(self, calendar_slug):
         try:
-            return CalendarEvent.objects.filter(calendar__slug=calendar_slug)
-        except CalendarEvent.DoesNotExist:
+            calendar = Calendar.objects.get(slug=calendar_slug)
+            return CalendarEvent.objects.filter(calendar=calendar)
+        except (Calendar.DoesNotExist, CalendarEvent.DoesNotExist):
             raise Http404
 
     def get(self, request, calendar_slug, format=None):


### PR DESCRIPTION
Like title, now API for calendar event list will return 404 for not exist calendar, but our front end section does not handle this scenario. So it still lead to empty calendar page, not the 404 page.

This is example for `http://localhost:8080/calendar/does-not-exist-calendar`
in console: `GET http://127.0.0.1:8000/api/calendar/does-not-exist-calendar/ 404 (Not Found)`