### PR TITLE
Gen event slug

### DIFF
--- a/skdue_calendar/api/v2/tests/test_me.py
+++ b/skdue_calendar/api/v2/tests/test_me.py
@@ -368,15 +368,15 @@ class UserMeTests(TestCase):
         )
         self.assertEqual(HTTP_200_OK, response.status_code)
         # find change data
-        response = self.client.get(reverse('api_v2:me_event', args=[self.calendar.slug, generate_slug(change_data["name"])]))
+        response = self.client.get(reverse('api_v2:me_event', args=[self.calendar.slug, self.private_event.slug]))
         response_data = convert_response(response.content)
         expect = json.dumps(CalendarEventSerializer(
             CalendarEvent.objects.get(name=change_data["name"])).data
         )
         self.assertJSONEqual(expect, response_data)
-        # find previous event (should not found)
-        response = self.client.get(reverse('api_v2:me_event', args=[self.calendar.slug, self.private_event.slug]))
-        self.assertEqual(HTTP_404_NOT_FOUND, response.status_code)
+        # test that event name does not change
+        event = CalendarEvent.objects.get(slug=self.private_event.slug)
+        self.assertEqual(change_data["name"], event.name)
 
     def test_me_event_put_dont_change_event_name(self):
         # change private event to public event but don't change name

--- a/skdue_calendar/api/v2/views/user_me.py
+++ b/skdue_calendar/api/v2/views/user_me.py
@@ -129,7 +129,21 @@ class UserMeCalendarView(APIView):
             event_data = request.data
             if CalendarEvent.is_valid(event_data, calendar_slug) and CalendarEvent.is_usable_tag(event_data["tag"], user_id=request.user.id):
                 calendar = Calendar.objects.get(slug=calendar_slug)
-                slug = generate_slug(event_data["name"])
+                # try to find available slug for an event
+                slug = ""
+                try:
+                    _ = CalendarEvent.objects.get(calendar=calendar, slug=generate_slug(event_data["name"]))
+                except CalendarEvent.DoesNotExist:
+                    slug = generate_slug(event_data["name"])
+                if slug == "":
+                    i = 0
+                    while 1:
+                        i += 1
+                        try:
+                            _ = CalendarEvent.objects.get(calendar=calendar, slug=generate_slug(event_data["name"])+f"-{i}")
+                        except CalendarEvent.DoesNotExist:
+                            slug = generate_slug(event_data["name"])+f"-{i}"
+                            break
                 tag = CalendarTag.objects.get(tag=event_data["tag"])
                 new_event = CalendarEvent(
                     calendar = calendar,
@@ -294,8 +308,6 @@ class UserMeEventView(APIView):
             else:
                 return Response({"msg": "invalid datetime"}, HTTP_400_BAD_REQUEST)
 
-            new_slug = generate_slug(request.data["name"])
-            event.slug = new_slug
             event.description = request.data["description"]
 
             event.save()
@@ -303,7 +315,7 @@ class UserMeEventView(APIView):
             return Response(
                     {
                         "msg": "changed event detail",
-                        "new_url": reverse('api_v2:me_event', args=[calendar_slug, new_slug])
+                        "new_url": reverse('api_v2:me_event', args=[calendar_slug, event.slug])
                     },
                     HTTP_200_OK
                 )

--- a/skdue_calendar/models/calendar_event.py
+++ b/skdue_calendar/models/calendar_event.py
@@ -39,20 +39,16 @@ class CalendarEvent(models.Model):
         Returns:
             bool: False, if calendar_slug does not exist or start_date < end_date, True otherwise.
         """
+        # we need same calendar name
         slug = generate_slug(event_data["name"])
-        is_same = False
         try:
             calendar = Calendar.objects.get(slug=calendar_slug)
-            for event in calendar.calendarevent_set.all():
-                if event.slug == slug:
-                    is_same = True
-                    break
         except:
             return False # calendar not found
 
         start_date = datetime.strptime(event_data["start_date"], "%Y-%m-%d %H:%M:%S")
         end_date = datetime.strptime(event_data["end_date"], "%Y-%m-%d %H:%M:%S")
-        return start_date < end_date and not is_same
+        return start_date < end_date
 
     @classmethod
     def is_usable_tag(self, tag_name, user_id):

--- a/skdue_calendar/tests/test_models_calendarevent.py
+++ b/skdue_calendar/tests/test_models_calendarevent.py
@@ -48,12 +48,9 @@ class CalendarEventModelTests(TestCase):
             with self.subTest():
                 self.assertFalse(CalendarEvent.is_valid(new_event, "calendar-0"), interval)
     
-    def test_invalid_event_with_same_name_in_same_calendar(self):
-        """Test that is_valid will return False when name is invalid.
-        New name is avaliable when the event name already exist in the same calendar.
+    def test_event_with_same_name_in_same_calendar(self):
+        """It fine that calendar event has the same name in the same calendar.
         """
-        # TODO: add tag (tag name from post request) from is_valid
-        # old event
         calendar_1 = Calendar.objects.get(slug="calendar-1")
         old_event = CalendarEvent(
             calendar = calendar_1,
@@ -71,7 +68,7 @@ class CalendarEventModelTests(TestCase):
             "tag_text": str(self.tag)
         }
         # validate with same name but different calendar
-        self.assertFalse(CalendarEvent.is_valid(new_event_data, "calendar-1"))
+        self.assertTrue(CalendarEvent.is_valid(new_event_data, "calendar-1"))
 
     def test_valid_event_with_valid_date(self):
         """Test that is_valid will return True when start date < end date"""


### PR DESCRIPTION
Update:

- Now, creating new event allow to create event with the same name in the same calendar.
- Edit event API no longer change event slug (after change event name, slug will be same with very first one).
- Remove duplicate event name checking in `CalendarEvent.isvalid`.
- Remove test for duplicate event name in `CalendarEvent` model test cases.
- Update test `test_me_event_put_change_event_name` in `test_me.py`